### PR TITLE
Add Spring Security integration and admin role creation view

### DIFF
--- a/pensamiento-computacional/pom.xml
+++ b/pensamiento-computacional/pom.xml
@@ -33,11 +33,15 @@
 		<jacoco.service.coverage.minimum>0.50</jacoco.service.coverage.minimum>
 	</properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+        <dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
@@ -53,11 +57,11 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-		<scope>runtime</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
@@ -81,17 +85,21 @@
                         <artifactId>jakarta.persistence-api</artifactId>
                         <version>3.1.0</version>
                 </dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-			<version>3.4.3</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                        <version>3.4.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.thymeleaf.extras</groupId>
+                        <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
 			<version>3.6.1</version>
 		</dependency>
- </dependencies>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/config/SecurityConfig.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package edu.icesi.pensamiento_computacional.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import edu.icesi.pensamiento_computacional.security.UserAccountDetailsService;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserAccountDetailsService userDetailsService;
+
+    public SecurityConfig(UserAccountDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/auth/login", "/auth/register", "/css/**", "/", "/Home").permitAll()
+                        .requestMatchers("/roles/**").hasRole("ADMIN")
+                        .anyRequest().permitAll())
+                .formLogin(login -> login
+                        .loginPage("/auth/login")
+                        .defaultSuccessUrl("/Home", true)
+                        .permitAll())
+                .logout(logout -> logout
+                        .logoutUrl("/auth/logout")
+                        .logoutSuccessUrl("/auth/login?logout")
+                        .permitAll());
+
+        http.authenticationProvider(authenticationProvider());
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder());
+        return authenticationProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/AuthController.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/AuthController.java
@@ -5,6 +5,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -30,6 +35,7 @@ public class AuthController {
 
     private final UserService userService;
     private final RoleRepository roleRepository;
+    private final AuthenticationManager authenticationManager;
 
     @GetMapping("/login")
     public String showLoginForm(Model model) {
@@ -49,6 +55,12 @@ public class AuthController {
         }
 
         try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginForm.getInstitutionalEmail(),
+                            loginForm.getPassword()));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
             UserAccount authenticatedUser = userService.authenticate(
                     loginForm.getInstitutionalEmail(),
                     loginForm.getPassword());
@@ -56,8 +68,8 @@ public class AuthController {
             redirectAttributes.addFlashAttribute("successMessage",
                     "Bienvenido, " + authenticatedUser.getFullName() + "!");
             return "redirect:/Home";
-        } catch (IllegalArgumentException ex) {
-            model.addAttribute("authenticationError", ex.getMessage());
+        } catch (AuthenticationException | IllegalArgumentException ex) {
+            model.addAttribute("authenticationError", "Correo o contraseña incorrectos.");
             return "auth/login";
         }
     }

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleController.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleController.java
@@ -1,0 +1,84 @@
+package edu.icesi.pensamiento_computacional.controller.mvc;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import edu.icesi.pensamiento_computacional.controller.mvc.form.RoleForm;
+import edu.icesi.pensamiento_computacional.model.Permission;
+import edu.icesi.pensamiento_computacional.model.Role;
+import edu.icesi.pensamiento_computacional.repository.PermissionRepository;
+import edu.icesi.pensamiento_computacional.services.RoleService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/roles")
+@RequiredArgsConstructor
+public class RoleController {
+
+    private final RoleService roleService;
+    private final PermissionRepository permissionRepository;
+
+    @GetMapping("/create")
+    public String showCreateRoleForm(Model model) {
+        if (!model.containsAttribute("roleForm")) {
+            model.addAttribute("roleForm", new RoleForm());
+        }
+        populatePermissions(model);
+        return "roles/create";
+    }
+
+    @PostMapping("/create")
+    public String createRole(@Valid @ModelAttribute("roleForm") RoleForm roleForm,
+            BindingResult bindingResult,
+            Model model,
+            RedirectAttributes redirectAttributes) {
+
+        if (bindingResult.hasErrors()) {
+            populatePermissions(model);
+            return "roles/create";
+        }
+
+        Role role = new Role();
+        role.setName(roleForm.getName());
+        role.setDescription(roleForm.getDescription());
+
+        Set<Permission> selectedPermissions = new HashSet<>();
+        roleForm.getPermissionIds().forEach(permissionId -> {
+            Permission permission = new Permission();
+            permission.setId(permissionId);
+            selectedPermissions.add(permission);
+        });
+        role.setPermissions(selectedPermissions);
+
+        try {
+            roleService.createRole(role);
+            redirectAttributes.addFlashAttribute("successMessage", "Rol creado correctamente.");
+            return "redirect:/roles/create";
+        } catch (IllegalArgumentException ex) {
+            bindingResult.rejectValue("permissionIds", "permission.invalid", ex.getMessage());
+        } catch (EntityNotFoundException ex) {
+            bindingResult.rejectValue("permissionIds", "permission.notfound", ex.getMessage());
+        } catch (DataIntegrityViolationException ex) {
+            bindingResult.rejectValue("name", "role.duplicate", "Ya existe un rol con este nombre.");
+        }
+
+        populatePermissions(model);
+        return "roles/create";
+    }
+
+    private void populatePermissions(Model model) {
+        model.addAttribute("permissions", permissionRepository.findAll());
+    }
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/form/RoleForm.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/form/RoleForm.java
@@ -1,0 +1,24 @@
+package edu.icesi.pensamiento_computacional.controller.mvc.form;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RoleForm {
+
+    @NotBlank(message = "El nombre del rol es obligatorio.")
+    private String name;
+
+    @NotBlank(message = "La descripción es obligatoria.")
+    private String description;
+
+    @NotEmpty(message = "Selecciona al menos un permiso.")
+    private Set<Integer> permissionIds = new HashSet<>();
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/security/UserAccountDetailsService.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/security/UserAccountDetailsService.java
@@ -1,0 +1,46 @@
+package edu.icesi.pensamiento_computacional.security;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import edu.icesi.pensamiento_computacional.model.Role;
+import edu.icesi.pensamiento_computacional.model.UserAccount;
+import edu.icesi.pensamiento_computacional.repository.UserAccountRepository;
+
+@Service
+public class UserAccountDetailsService implements UserDetailsService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public UserAccountDetailsService(UserAccountRepository userAccountRepository) {
+        this.userAccountRepository = userAccountRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserAccount userAccount = userAccountRepository.findByInstitutionalEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException(
+                        "No se encontró un usuario con el correo institucional proporcionado."));
+
+        Set<String> authorities = userAccount.getRoles().stream()
+                .map(Role::getName)
+                .map(roleName -> "ROLE_" + roleName.toUpperCase())
+                .collect(Collectors.toSet());
+
+        return User.builder()
+                .username(userAccount.getInstitutionalEmail())
+                .password(userAccount.getPasswordHash())
+                .authorities(authorities.toArray(String[]::new))
+                .accountLocked(false)
+                .accountExpired(false)
+                .credentialsExpired(false)
+                .disabled(false)
+                .build();
+    }
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/Impl/UserServiceImpl.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/Impl/UserServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,10 +21,13 @@ public class UserServiceImpl implements UserService {
 
     private final UserAccountRepository userAccountRepository;
     private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserServiceImpl(UserAccountRepository userAccountRepository, RoleRepository roleRepository) {
+    public UserServiceImpl(UserAccountRepository userAccountRepository, RoleRepository roleRepository,
+            PasswordEncoder passwordEncoder) {
         this.userAccountRepository = userAccountRepository;
         this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -56,6 +60,7 @@ public class UserServiceImpl implements UserService {
         }
 
         user.setRoles(managedRoles);
+        user.setPasswordHash(passwordEncoder.encode(user.getPasswordHash()));
         return userAccountRepository.save(user);
     }
 
@@ -66,7 +71,11 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new EntityNotFoundException("User account not found with id " + id));
 
         existingUser.setInstitutionalEmail(user.getInstitutionalEmail());
-        existingUser.setPasswordHash(user.getPasswordHash());
+        if (user.getPasswordHash() == null || user.getPasswordHash().isBlank()) {
+            throw new IllegalArgumentException("La contraseña es obligatoria.");
+        }
+
+        existingUser.setPasswordHash(passwordEncoder.encode(user.getPasswordHash()));
         existingUser.setFullName(user.getFullName());
         existingUser.setProfilePhotoUrl(user.getProfilePhotoUrl());
         existingUser.setCreatedAt(user.getCreatedAt());
@@ -98,7 +107,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserAccount authenticate(String institutionalEmail, String password) {
         return userAccountRepository.findByInstitutionalEmail(institutionalEmail)
-                .filter(user -> password != null && password.equals(user.getPasswordHash()))
+                .filter(user -> password != null && passwordEncoder.matches(password, user.getPasswordHash()))
                 .orElseThrow(() -> new IllegalArgumentException("Correo o contraseña incorrectos."));
     }
 

--- a/pensamiento-computacional/src/main/resources/templates/home.html
+++ b/pensamiento-computacional/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -64,8 +64,9 @@
         <h1>Esta es la pagina principal</h1>
         <p>Accede con tu cuenta para continuar o crea una nueva si es tu primera vez.</p>
         <div class="action-buttons">
-            <a th:href="@{/auth/login}">Iniciar sesión</a>
-            <a th:href="@{/auth/register}">Registrarme</a>
+            <a sec:authorize="isAnonymous()" th:href="@{/auth/login}">Iniciar sesión</a>
+            <a sec:authorize="isAnonymous()" th:href="@{/auth/register}">Registrarme</a>
+            <a sec:authorize="hasRole('ADMIN')" th:href="@{/roles/create}">Crear roles</a>
         </div>
     </div>
 </body>

--- a/pensamiento-computacional/src/main/resources/templates/roles/create.html
+++ b/pensamiento-computacional/src/main/resources/templates/roles/create.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Crear rol</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f8fafc;
+            color: #1f2937;
+            min-height: 100vh;
+        }
+
+        header {
+            background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+            color: #fff;
+            padding: 1.5rem 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        header a {
+            color: #e0e7ff;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        main {
+            max-width: 960px;
+            margin: 2rem auto;
+            background: #fff;
+            padding: 2rem;
+            border-radius: 16px;
+            box-shadow: 0 15px 30px rgba(30, 64, 175, 0.12);
+        }
+
+        h1 {
+            margin-bottom: 1rem;
+        }
+
+        form {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        label {
+            font-weight: 600;
+        }
+
+        input[type="text"],
+        textarea,
+        select {
+            padding: 0.75rem 1rem;
+            border: 1px solid #cbd5f5;
+            border-radius: 10px;
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        textarea {
+            min-height: 120px;
+            resize: vertical;
+        }
+
+        input:focus,
+        textarea:focus,
+        select:focus {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+        }
+
+        .field-error {
+            color: #dc2626;
+            font-size: 0.875rem;
+        }
+
+        .form-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        button {
+            background: linear-gradient(135deg, #2563eb, #1d4ed8);
+            color: white;
+            border: none;
+            border-radius: 999px;
+            padding: 0.75rem 2rem;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 30px rgba(37, 99, 235, 0.25);
+        }
+
+        .alert {
+            padding: 0.85rem 1rem;
+            border-radius: 10px;
+            margin-bottom: 1rem;
+        }
+
+        .alert-success {
+            background-color: rgba(34, 197, 94, 0.15);
+            color: #15803d;
+            border: 1px solid rgba(22, 163, 74, 0.2);
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h2>Administración de roles</h2>
+        <nav>
+            <a th:href="@{/Home}">Volver al inicio</a>
+        </nav>
+    </header>
+
+    <main>
+        <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+        <h1>Crear rol</h1>
+        <p>Completa la información del rol y selecciona los permisos que se asociarán.</p>
+
+        <form th:action="@{/roles/create}" th:object="${roleForm}" method="post">
+            <div class="form-group">
+                <label for="name">Nombre del rol</label>
+                <input id="name" type="text" th:field="*{name}" placeholder="Ej: ADMIN" />
+                <div class="field-error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+            </div>
+
+            <div class="form-group">
+                <label for="description">Descripción</label>
+                <textarea id="description" th:field="*{description}" placeholder="Describe las responsabilidades del rol"></textarea>
+                <div class="field-error" th:if="${#fields.hasErrors('description')}" th:errors="*{description}"></div>
+            </div>
+
+            <div class="form-group">
+                <label for="permissionIds">Permisos disponibles</label>
+                <select id="permissionIds" th:field="*{permissionIds}" multiple size="6">
+                    <option th:each="permission : ${permissions}" th:value="${permission.id}"
+                        th:text="${permission.name}"></option>
+                </select>
+                <small>Usa Ctrl (o Cmd) para seleccionar múltiples permisos.</small>
+                <div class="field-error" th:if="${#fields.hasErrors('permissionIds')}" th:errors="*{permissionIds}"></div>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit">Crear rol</button>
+            </div>
+        </form>
+    </main>
+</body>
+</html>

--- a/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/PensamientoComputacionalControllerTest.java
+++ b/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/PensamientoComputacionalControllerTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,6 +33,7 @@ import edu.icesi.pensamiento_computacional.repository.TeachingAssignmentReposito
 import edu.icesi.pensamiento_computacional.repository.UserAccountRepository;
 
 @WebMvcTest(PensamientoComputacionalController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class PensamientoComputacionalControllerTest {
 
     @Autowired

--- a/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/services/UserServiceTest.java
+++ b/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/services/UserServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -16,12 +18,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import edu.icesi.pensamiento_computacional.model.Role;
 import edu.icesi.pensamiento_computacional.model.UserAccount;
@@ -39,8 +43,21 @@ class UserServiceTest {
     @Mock
     private RoleRepository roleRepository;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
     @InjectMocks
     private UserServiceImpl userService;
+
+    @BeforeEach
+    void setupEncoder() {
+        lenient().when(passwordEncoder.encode(anyString())).thenAnswer(invocation -> "encoded-" + invocation.getArgument(0));
+        lenient().when(passwordEncoder.matches(anyString(), anyString())).thenAnswer(invocation -> {
+            String raw = invocation.getArgument(0);
+            String encoded = invocation.getArgument(1);
+            return encoded.equals("encoded-" + raw) || encoded.equals(raw);
+        });
+    }
 
     @Test
     void createUser_withValidRoles_persistsUser() {
@@ -130,7 +147,7 @@ class UserServiceTest {
         UserAccount updatedUser = userService.updateUser(existingUser.getId(), userChanges);
 
         assertEquals(userChanges.getInstitutionalEmail(), updatedUser.getInstitutionalEmail());
-        assertEquals(userChanges.getPasswordHash(), updatedUser.getPasswordHash());
+        assertEquals("encoded-" + userChanges.getPasswordHash(), updatedUser.getPasswordHash());
         assertEquals(userChanges.getFullName(), updatedUser.getFullName());
         assertEquals(userChanges.getProfilePhotoUrl(), updatedUser.getProfilePhotoUrl());
         assertEquals(userChanges.getCreatedAt(), updatedUser.getCreatedAt());


### PR DESCRIPTION
## Summary
- configure Spring Security with a custom `UserDetailsService`, password encoder, and MVC login flow updates
- add an admin-only role creation controller, form object, and Thymeleaf template with permission selection
- update existing templates and tests to work with the new security rules and encoded passwords

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e48453b67c832e8d64056f996b1349