### PR TITLE
Update demo account passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ mvn spring-boot:run
 - **Database:** H2 (in-memory)
 - **H2 Console:** http://192.168.131.107:8089/pcomputacional/h2-console
 
+## Demo accounts
+
+The seeded users in `data.sql` authenticate with their institutional email and the following plain-text passwords:
+
+| Email | Password |
+| --- | --- |
+| `user1@icesi.edu.co` | `user1pass` |
+| `user2@icesi.edu.co` | `user2pass` |
+| `user3@icesi.edu.co` | `user3pass` |
+| `user4@icesi.edu.co` | `user4pass` |
+| `user5@icesi.edu.co` | `user5pass` |
+
+These values correspond to the BCrypt digests stored in `pensamiento-computacional/src/main/resources/data.sql`.
+
 ## API Endpoints
 
 **Base URL:** `http://192.168.131.107:8089/pcomputacional`

--- a/pensamiento-computacional/src/main/resources/data.sql
+++ b/pensamiento-computacional/src/main/resources/data.sql
@@ -1,11 +1,11 @@
 -- Tabla: USER_ACCOUNT
 INSERT INTO USER_ACCOUNT (id, institutional_email, password_hash, full_name, profile_photo_url, created_at, self_declared_level)
 VALUES
-(1, 'user1@icesi.edu.co', 'hash1', 'User Uno', NULL, CURRENT_TIMESTAMP, NULL),
-(2, 'user2@icesi.edu.co', 'hash2', 'User Dos', NULL, CURRENT_TIMESTAMP, NULL),
-(3, 'user3@icesi.edu.co', 'hash3', 'User Tres', NULL, CURRENT_TIMESTAMP, NULL),
-(4, 'user4@icesi.edu.co', 'hash4', 'User Cuatro', NULL, CURRENT_TIMESTAMP, NULL),
-(5, 'user5@icesi.edu.co', 'hash5', 'User Cinco', NULL, CURRENT_TIMESTAMP, NULL);
+(1, 'user1@icesi.edu.co', '$2a$10$SsreIeaOxvvMtRxlPNxnwOynxJXI72QaHUdajMjyN/iXGVP9zGoeK', 'User Uno', NULL, CURRENT_TIMESTAMP, NULL),
+(2, 'user2@icesi.edu.co', '$2a$10$MIpC9S68xS7UjB7kp9Pmous9yzYfKTwwkAj5Ur0OB7Wn3GVY6uGUO', 'User Dos', NULL, CURRENT_TIMESTAMP, NULL),
+(3, 'user3@icesi.edu.co', '$2a$10$1mYcpvaCSyqBb7AYhIG6w.ujC1gxCMPxAWUE7aElECk2tWWWGgUj2', 'User Tres', NULL, CURRENT_TIMESTAMP, NULL),
+(4, 'user4@icesi.edu.co', '$2a$10$59pDBihOSH8OaZFqQ.YmaOwXCVlsyy.tS9BMxwr1YrA09/k3thYdu', 'User Cuatro', NULL, CURRENT_TIMESTAMP, NULL),
+(5, 'user5@icesi.edu.co', '$2a$10$tqIVfKcfOBcatzA8JZGEtOxzkyQmBBFCG8ZHUcgbdF3kem.HULdrq', 'User Cinco', NULL, CURRENT_TIMESTAMP, NULL);
 
 ALTER TABLE USER_ACCOUNT ALTER COLUMN id RESTART WITH 6;
 


### PR DESCRIPTION
## Summary
- replace the placeholder password hashes for the seeded user accounts with BCrypt digests that match the documented demo passwords
- document the expected plain-text credentials for the demo accounts in the README so they line up with the updated seed data

## Testing
- `./mvnw -Dmaven.test.skip=true spring-boot:run` *(to start the application for manual login verification, then terminated)*
- `curl -i -c /tmp/cookies.txt -d "username=user1@icesi.edu.co&password=user1pass" -X POST http://localhost:8081/pcomputacional/auth/login`
- `curl -i -b /tmp/cookies.txt http://localhost:8081/pcomputacional/Home`

------
https://chatgpt.com/codex/tasks/task_e_68e496bfae44832e9ad6df7a58e2df43