### PR TITLE
Add explicit UserService authentication workflow

### DIFF
--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/Impl/UserServiceImpl.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/Impl/UserServiceImpl.java
@@ -104,6 +104,18 @@ public class UserServiceImpl implements UserService {
         return userAccountRepository.findAll();
     }
 
+    @Override
+    public UserAccount authenticate(String institutionalEmail, String rawPassword) {
+        UserAccount userAccount = userAccountRepository.findByInstitutionalEmail(institutionalEmail)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid institutional email or password."));
+
+        if (!passwordEncoder.matches(rawPassword, userAccount.getPasswordHash())) {
+            throw new IllegalArgumentException("Invalid institutional email or password.");
+        }
+
+        return userAccount;
+    }
+
 
     private Set<Role> loadRoles(Set<Role> roles) {
         if (roles == null || roles.isEmpty()) {

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/UserService.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/UserService.java
@@ -11,4 +11,5 @@ public interface UserService {
     void deleteUser(Integer id);
     UserAccount getUserById(Integer id);
     List<UserAccount> getAllUsers();
+    UserAccount authenticate(String institutionalEmail, String rawPassword);
 }

--- a/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/services/UserServiceTest.java
+++ b/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/services/UserServiceTest.java
@@ -273,6 +273,15 @@ class UserServiceTest {
                 () -> userService.authenticate(storedUser.getInstitutionalEmail(), "wrong"));
     }
 
+    @Test
+    void authenticate_withUnknownEmail_throwsException() {
+        when(userAccountRepository.findByInstitutionalEmail("unknown@icesi.edu.co"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> userService.authenticate("unknown@icesi.edu.co", "password"));
+    }
+
     private UserAccount buildUser(Set<Role> roles) {
         UserAccount user = new UserAccount();
         user.setInstitutionalEmail("user@icesi.edu.co");


### PR DESCRIPTION
## Summary
- declare an authenticate contract on UserService
- implement credential validation in UserServiceImpl using the repository and password encoder
- cover valid, invalid password, and unknown email scenarios in UserServiceTest

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_e_68e49c17aa4c832e94c85864904f1f20