### PR TITLE
Enforce authentication checks on role and user MVC pages

### DIFF
--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleController.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleController.java
@@ -20,6 +20,7 @@ import edu.icesi.pensamiento_computacional.model.Permission;
 import edu.icesi.pensamiento_computacional.model.Role;
 import edu.icesi.pensamiento_computacional.repository.PermissionRepository;
 import edu.icesi.pensamiento_computacional.services.RoleService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,11 @@ public class RoleController {
     private final PermissionRepository permissionRepository;
 
     @GetMapping("/create")
-    public String showCreateRoleForm(Model model) {
+    public String showCreateRoleForm(HttpSession session, Model model) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         if (!model.containsAttribute("roleForm")) {
             model.addAttribute("roleForm", new RoleForm());
         }
@@ -43,10 +48,16 @@ public class RoleController {
     }
 
     @PostMapping("/create")
-    public String createRole(@Valid @ModelAttribute("roleForm") RoleForm roleForm,
+    public String createRole(HttpSession session,
+            @Valid @ModelAttribute("roleForm") RoleForm roleForm,
             BindingResult bindingResult,
             Model model,
             RedirectAttributes redirectAttributes) {
+
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
 
         if (bindingResult.hasErrors()) {
             populatePermissions(model);
@@ -82,7 +93,11 @@ public class RoleController {
     }
 
     @GetMapping("/assign-permissions")
-    public String showAssignPermissions(Model model) {
+    public String showAssignPermissions(HttpSession session, Model model) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         if (!model.containsAttribute("assignmentForm")) {
             model.addAttribute("assignmentForm", new RolePermissionAssignmentForm());
         }
@@ -92,10 +107,16 @@ public class RoleController {
     }
 
     @PostMapping("/assign-permissions")
-    public String assignPermissions(@Valid @ModelAttribute("assignmentForm") RolePermissionAssignmentForm assignmentForm,
+    public String assignPermissions(HttpSession session,
+            @Valid @ModelAttribute("assignmentForm") RolePermissionAssignmentForm assignmentForm,
             BindingResult bindingResult,
             Model model,
             RedirectAttributes redirectAttributes) {
+
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
 
         if (bindingResult.hasErrors()) {
             populateRoles(model);
@@ -133,13 +154,23 @@ public class RoleController {
     }
 
     @GetMapping("/manage")
-    public String showRoleManagement(Model model) {
+    public String showRoleManagement(HttpSession session, Model model) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         model.addAttribute("roles", roleService.getAllRoles());
         return "roles/manage";
     }
 
     @PostMapping("/{roleId}/delete")
-    public String deleteRole(@PathVariable Integer roleId, RedirectAttributes redirectAttributes) {
+    public String deleteRole(HttpSession session,
+            @PathVariable Integer roleId,
+            RedirectAttributes redirectAttributes) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         try {
             roleService.deleteRole(roleId);
             redirectAttributes.addFlashAttribute("successMessage", "Rol eliminado correctamente.");
@@ -158,5 +189,12 @@ public class RoleController {
 
     private void populateRoles(Model model) {
         model.addAttribute("roles", roleService.getAllRoles());
+    }
+
+    private String redirectIfNotAuthenticated(HttpSession session) {
+        if (session.getAttribute(AuthController.SESSION_USER_ID) == null) {
+            return "redirect:/auth/login";
+        }
+        return null;
     }
 }

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/UserController.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/UserController.java
@@ -16,6 +16,7 @@ import edu.icesi.pensamiento_computacional.controller.mvc.form.UserRoleRemovalFo
 import edu.icesi.pensamiento_computacional.model.UserAccount;
 import edu.icesi.pensamiento_computacional.services.RoleService;
 import edu.icesi.pensamiento_computacional.services.UserService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,14 +32,22 @@ public class UserController {
 
 
     @GetMapping("userList")
-    public String getUsers(Model model){
+    public String getUsers(HttpSession session, Model model){
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         List<UserAccount> users  = userService.getAllUsers();
         model.addAttribute("users", users);
         return ("userList");
     }
 
     @GetMapping("/assign-roles")
-    public String showAssignRoles(Model model) {
+    public String showAssignRoles(HttpSession session, Model model) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         if (!model.containsAttribute("assignmentForm")) {
             model.addAttribute("assignmentForm", new UserRoleAssignmentForm());
         }
@@ -47,10 +56,16 @@ public class UserController {
     }
 
     @PostMapping("/assign-roles")
-    public String assignRoles(@Valid @ModelAttribute("assignmentForm") UserRoleAssignmentForm assignmentForm,
+    public String assignRoles(HttpSession session,
+            @Valid @ModelAttribute("assignmentForm") UserRoleAssignmentForm assignmentForm,
             BindingResult bindingResult,
             Model model,
             RedirectAttributes redirectAttributes) {
+
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
 
         if (bindingResult.hasErrors()) {
             populateUsersAndRoles(model);
@@ -72,7 +87,11 @@ public class UserController {
     }
 
     @GetMapping("/remove-roles")
-    public String showRemoveRoles(Model model) {
+    public String showRemoveRoles(HttpSession session, Model model) {
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
         if (!model.containsAttribute("removalForm")) {
             model.addAttribute("removalForm", new UserRoleRemovalForm());
         }
@@ -81,10 +100,16 @@ public class UserController {
     }
 
     @PostMapping("/remove-roles")
-    public String removeRoles(@Valid @ModelAttribute("removalForm") UserRoleRemovalForm removalForm,
+    public String removeRoles(HttpSession session,
+            @Valid @ModelAttribute("removalForm") UserRoleRemovalForm removalForm,
             BindingResult bindingResult,
             Model model,
             RedirectAttributes redirectAttributes) {
+
+        String redirect = redirectIfNotAuthenticated(session);
+        if (redirect != null) {
+            return redirect;
+        }
 
         if (bindingResult.hasErrors()) {
             populateUsersAndRoles(model);
@@ -108,5 +133,12 @@ public class UserController {
     private void populateUsersAndRoles(Model model) {
         model.addAttribute("users", userService.getAllUsers());
         model.addAttribute("roles", roleService.getAllRoles());
+    }
+
+    private String redirectIfNotAuthenticated(HttpSession session) {
+        if (session.getAttribute(AuthController.SESSION_USER_ID) == null) {
+            return "redirect:/auth/login";
+        }
+        return null;
     }
 }

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/UserService.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/services/UserService.java
@@ -13,4 +13,6 @@ public interface UserService {
     UserAccount getUserById(Integer id);
     List<UserAccount> getAllUsers();
     UserAccount authenticate(String institutionalEmail, String rawPassword);
+    void assignRoles(Integer userId, Set<Integer> roleIds);
+    void removeRoles(Integer userId, Set<Integer> roleIds);
 }

--- a/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleControllerTest.java
+++ b/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/mvc/RoleControllerTest.java
@@ -1,0 +1,36 @@
+package edu.icesi.pensamiento_computacional.controller.mvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import edu.icesi.pensamiento_computacional.repository.PermissionRepository;
+import edu.icesi.pensamiento_computacional.services.RoleService;
+
+@WebMvcTest(RoleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RoleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoleService roleService;
+
+    @MockBean
+    private PermissionRepository permissionRepository;
+
+    @Test
+    void unauthenticatedUserIsRedirectedToLoginOnCreateForm() throws Exception {
+        mockMvc.perform(get("/roles/create"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/auth/login"));
+    }
+}

--- a/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/mvc/UserControllerTest.java
+++ b/pensamiento-computacional/src/test/java/edu/icesi/pensamiento_computacional/controller/mvc/UserControllerTest.java
@@ -1,0 +1,36 @@
+package edu.icesi.pensamiento_computacional.controller.mvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import edu.icesi.pensamiento_computacional.services.RoleService;
+import edu.icesi.pensamiento_computacional.services.UserService;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private RoleService roleService;
+
+    @Test
+    void unauthenticatedUserIsRedirectedToLoginOnUserList() throws Exception {
+        mockMvc.perform(get("/users/userList"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/auth/login"));
+    }
+}


### PR DESCRIPTION
## Summary
- add HttpSession guards to the role and user MVC controllers to redirect unauthenticated users to the login page
- expose role assignment and removal operations through the user service implementation
- cover the new unauthenticated redirect paths with dedicated MVC tests

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e4a8943d2c832eb9ea955bdd734ab9