### PR TITLE
Update dashboard navigation to authenticated home

### DIFF
--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/AuthController.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/controller/mvc/AuthController.java
@@ -68,7 +68,7 @@ public class AuthController {
 
             redirectAttributes.addFlashAttribute("successMessage",
                     "Bienvenido, " + displayName + "!");
-            return "redirect:/Home";
+            return "redirect:/dashboard";
         } catch (IllegalArgumentException ex) {
             model.addAttribute("authenticationError", "Correo o contraseña incorrectos.");
             return "auth/login";

--- a/pensamiento-computacional/src/main/resources/templates/dashboard.html
+++ b/pensamiento-computacional/src/main/resources/templates/dashboard.html
@@ -103,7 +103,7 @@
             <p style="margin: 0.25rem 0 0 0; opacity: 0.85;" th:text="${displayName != null ? 'Hola, ' + displayName + ' 👋' : 'Hola 👋'}"></p>
         </div>
         <nav>
-            <a th:href="@{/Home}">Inicio público</a>
+            <a th:href="@{/dashboard}">Inicio del panel</a>
             <a th:href="@{/auth/logout}">Cerrar sesión</a>
         </nav>
     </header>

--- a/pensamiento-computacional/src/main/resources/templates/roles/create.html
+++ b/pensamiento-computacional/src/main/resources/templates/roles/create.html
@@ -124,9 +124,7 @@
     <header>
         <h2>Administración de roles</h2>
         <nav>
-            <a th:href="@{/dashboard}">Panel principal</a>
-            <span style="margin: 0 0.75rem; color: rgba(224, 231, 255, 0.7);">|</span>
-            <a th:href="@{/Home}">Inicio público</a>
+            <a th:href="@{/dashboard}">Inicio del panel</a>
         </nav>
     </header>
 


### PR DESCRIPTION
## Summary
- point the dashboard navigation back to the authenticated home route and update the copy
- align the role creation header navigation with the dashboard route
- redirect successful login flows to the dashboard instead of the public home page

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e4ab1c4bec832e927c5606bb11a347